### PR TITLE
docs: switch datalearner to khang medium

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -285,8 +285,8 @@ const config = {
                 to: 'blog',
               },
               {
-                label: 'Data learner',
-                href: 'https://www.datalearner.org/',
+                label: 'medium.com/@nguyenkhangme',
+                href: 'https://medium.com/@nguyenkhangme',
               },
             ],
           },

--- a/src/components/homepage/SDKsSection.jsx
+++ b/src/components/homepage/SDKsSection.jsx
@@ -101,7 +101,7 @@ export default function SDKsSection() {
               <Pill section="Nền tảng" />
               <Pill section="Nhập môn" />
               <Pill section="Trung bình" />
-              <Pill section="Data Learner" />
+              <Pill section="AI/ML trong thực tiễn" />
             </div>
           </div>
         </div>
@@ -342,16 +342,17 @@ export default function SDKsSection() {
 
         <div
           className="sdk-section mb-16 flex flex-col rounded-3xl bg-secondary-900 lg:flex-row"
-          data-section="Data Learner"
-          id="Data Learner"
+          data-section="AI/ML trong thực tiễn"
+          id="AI/ML trong thực tiễn"
         >
           <div className="flex flex-1 flex-col justify-center p-6 text-center lg:pl-16 lg:text-left">
-            <h3 className="text-4xl font-semibold">Data Learner</h3>
+            <h3 className="text-4xl font-semibold">AI/ML trong thực tiễn</h3>
             <p className="text-sm leading-relaxed text-text-400 lg:max-w-sm">
-              Là trang liên kết với Khoahocdulieu.org, datalearner.org sử dụng ngôn ngữ Tiếng Anh, 
-              cung cấp các nội dung đơn giản, ngắn gọn, dễ học về các công cụ cho người học dữ liệu trong thực tiễn
+              medium.com/@nguyenkhangme
+              Là trang Medium của Founder Nguyên Khang, trang sử dụng ngôn ngữ Tiếng Anh,
+              tập trung chủ yếu vào triển khai AI/ML trong thực tiễn.
             </p>
-            <Link className="text-sm" href="https://www.datalearner.org">
+            <Link className="text-sm" href="https://medium.com/@nguyenkhangme">
               Ghé trang &rarr;
             </Link>
           </div>

--- a/src/pages/site-health.mdx
+++ b/src/pages/site-health.mdx
@@ -2,10 +2,8 @@
 title: Site Health
 ---
 
-# Site Health
-
 key |   value
 :---------: | :----------------------------------:
-the last git commit | [3910d26](https://github.com/DataLearner-org/DataLearner.org/commit/3910d265172e6b468e562f522a64ad7f3b7c92bf)
-the most recent deploy date | 2023-04-22T01:51:33
-the public website monitoring dashboard | <img src="/img/check.svg" width="16" height="16" />[statuspage.freshping.io](https://statuspage.freshping.io/66131-Datalearnerorg)
+the last git commit | [2bf75dd](https://github.com/Khoa-Hoc-Du-Lieu/docs/commit/2bf75dd6b0206b51dae65d3cf27b627d37c67340)
+the most recent deploy date | 2025-07-18T02:12:15
+the public website monitoring dashboard | <img src="/img/check.svg" width="16" height="16" />[statuspage.freshping.io](https://statuspage.freshping.io/66228-Khoahocdulieuorg)

--- a/src/snippets/resources.html
+++ b/src/snippets/resources.html
@@ -70,9 +70,9 @@
       </a>
     </li>
     <li>
-      <a href="https://www.datalearner.org" target="_blank" class="flex items-center gap-2 text-inherit">
+      <a href="https://medium.com/@nguyenkhangme" target="_blank" class="flex items-center gap-2 text-inherit">
         <img src="/static/landing-page/sdk-icons/resources/book-open.svg" />
-        DataLearner
+        Founder's Medium
       </a>
     </li>
   </ul>


### PR DESCRIPTION
## Description

switch datalearner to khang medium

problem: Datalearner is abandoned, now AI/ML in practical is in Khang's Medium

## Resolved issues

Closes #37 

### Before submitting the PR, please take the following into consideration
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. If you don't have an issue, please create one.
- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
- [x] The description should clearly illustrate what problems it solves.
- [x] Ensure that the commit messages follow our guidelines.
- [x] Resolve merge conflicts (if any).
- [x] Make sure that the current branch is upto date with the `main` branch.
